### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Real Machine-Dependent options:
 
 * `eval_interval ` controls the interval between every two evaluations. 
 
-* `num_threads` is the number of threads in the clients computing session that aims to accelarate the training process.
+* `num_threads` is the number of threads in the clients computing session that aims to accelerate the training process.
 
 * `num_workers` is the number of workers of the torch.utils.data.Dataloader
 


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "accelarate" to "accelerate" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.****